### PR TITLE
chore: [SETI-1159] :construction_worker: add ci standard workflow

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:
-      - main 
-  
+      - main
 
 jobs:
   ci-standard-checks:


### PR DESCRIPTION

:warning: As a code owner, you are expected to review and merge (the bot will not merge by itself).
This PR adds the Typeform's CI Standard check to the PR that will do:
- a JIRA link check
- the Secret scan check

This PR will help you with gain 2 badges:
- Secrets Scan check (mandatory for Q2)
- CI Standard Checks (informative for Q2, mandatory for Q3)

This means that if you already have a a secrets detection workflow / part of travis in your repo, you can safely delete it without affecting the badge ratio. 
This PR should have deleted the 'secrets-scan.yml' from your repo. 

Note: if you have the secrets-detection workflow in pending after deletion, it means that it's a mandatory check in a protected branch. 
Please go to Settings -> Branches -> Edit Protected Branch -> Uncheck secrets-scan

To learn more about this standard, go here: https://www.notion.so/typeform/Repository-s-automated-checks-e03b09e5d71542e595f9dd128f4fe917

:robot: I'm a  bot, if you have any doubts, contact #seti-team on slack.