### PR TITLE
chore(SP-1216): updating gitleaks-config call

### DIFF
--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -38,10 +38,9 @@ gitleaks_version="v7.2.0"
 # Generate the final gitleaks config file. If the repo has a local config, merge both
 if [ -f ./"$local_config" ]; then
     docker container run --rm -v $repo_dir/$local_config:/app/$local_config \
-    $gitleaks_config_container python gitleaks_config_generator.py > $final_config
+    $gitleaks_config_container > $final_config
 else
-    docker container run --rm $gitleaks_config_container \
-    python gitleaks_config_generator.py > $final_config
+    docker container run --rm $gitleaks_config_container > $final_config
 fi
 
 if [ -z "${GITHUB_BASE_REF}" ]; then


### PR DESCRIPTION
This `gitleaks-config` PR [changed the Dockerfile entrypoint](https://github.com/Typeform/gitleaks-config/pull/33/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R11) of `gitleaks-config`. Now the `CMD` has the default call which is to calculate the `gitleaks` configuration file and print it to `STDOUT`.

Therefore, we can remove the redundant call.