### PR TITLE
feat(SP-1221): PII detection check

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@octokit/types": "^6.18.1",
-    "@octokit/webhooks": "^9.8.4"
+    "@octokit/webhooks": "^9.8.4",
+    "csv-reader": "^1.0.8"
   },
   "devDependencies": {
     "@typeform/eslint-config": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@octokit/types": "^6.19.1",
-    "@octokit/webhooks": "^9.11.0"
+    "@octokit/webhooks": "^9.11.0",
     "csv-reader": "^1.0.8"
   },
   "devDependencies": {

--- a/src/checks/piiDetection.test.ts
+++ b/src/checks/piiDetection.test.ts
@@ -1,0 +1,183 @@
+import { mocked } from 'ts-jest/utils'
+
+import { Content, github } from '../infrastructure/github'
+
+import {
+  CsvDetectionThreshold,
+  getFilesToIgnore,
+  getCandidateFiles,
+  isFileExtensionToBeScanned,
+  IGNOREFILE,
+  Prediction,
+  scanCsvForPii,
+} from './piiDetection'
+
+const mockGithub = mocked(github, true)
+
+jest.mock('../infrastructure/github')
+
+class HTTPError extends Error {
+  status: number
+  constructor(code: number, message: string) {
+    super(message)
+    this.status = code
+  }
+}
+
+const sampleDownloadFileResponse: Content = {
+  content: Buffer.from('hello').toString('base64'),
+  download_url:
+    'https://raw.githubusercontent.com/Typeform/ci-standard-checks/185044902e85ee654c0897825bf18aa040604b56/scripts/secrets-scan/run.sh',
+  encoding: 'base64',
+  git_url:
+    'https://api.github.com/repos/Typeform/ci-standard-checks/git/blobs/e38f43b95777e36d3c147660b288d2e8a3a6ea27',
+  html_url:
+    'https://github.com/Typeform/ci-standard-checks/blob/185044902e85ee654c0897825bf18aa040604b56/scripts/secrets-scan/run.sh',
+  name: 'run.sh',
+  path: 'scripts/secrets-scan/run.sh',
+  sha: 'e38f43b95777e36d3c147660b288d2e8a3a6ea27',
+  size: 3020,
+  type: 'file',
+  url: 'https://api.github.com/repos/Typeform/ci-standard-checks/contents/scripts/secrets-scan/run.sh?ref=185044902e85ee654c0897825bf18aa040604b56',
+  _links: {
+    git: null,
+    html: null,
+    self: '',
+  },
+}
+
+describe('scanCsvForPii', () => {
+  it('returns a prediction with a positive detection of type us-phone-number when the content contains that type of data', async () => {
+    const sampleData = `data,data,data,+1 800 444 4444,data
+data,data,data,+1 800 444 4444,data
+data,data,data,+1 800 444 4444,data
+`
+    const expectedPrediction: Prediction = {
+      detected: true,
+      dataType: ['us-phone-number'],
+    }
+
+    const actualPrediction = await scanCsvForPii(
+      sampleData,
+      CsvDetectionThreshold
+    )
+
+    expect(actualPrediction).toEqual(expectedPrediction)
+  })
+
+  it('returns a prediction with a negative detection when there are less than CsvDetectionThreshold * csv_lines items', async () => {
+    const sampleData = `data,data,data,+1 800 444 4444,data
+data,data,data,+1 800 444 4444,data
+data,data,data,+1 800 444 4444,data
+data,data,data,data,data
+data,data,data,data,data
+data,data,data,data,data
+data,data,data,data,data
+data,data,data,data,data
+data,data,data,data,data
+data,data,data,data,data
+`
+    const expectedPrediction: Prediction = {
+      detected: false,
+      dataType: [],
+    }
+
+    const actualPrediction = await scanCsvForPii(
+      sampleData,
+      CsvDetectionThreshold
+    )
+
+    expect(actualPrediction).toEqual(expectedPrediction)
+  })
+
+  it('returns a prediction with a positive detection of type email and ssn when those are present in the content', async () => {
+    const sampleData = `data,489-36-8350,data,someone@mail.com,data
+data,514-14-8905,data,another.person@mail.co.uk,data
+data,690-05-5315,data,my@personal.mail,data
+`
+    const expectedPrediction: Prediction = {
+      detected: true,
+      dataType: ['email', 'ssn'],
+    }
+
+    const actualPrediction = await scanCsvForPii(
+      sampleData,
+      CsvDetectionThreshold
+    )
+
+    expect(actualPrediction).toEqual(expectedPrediction)
+  })
+})
+
+describe('getFilesToIgnore', () => {
+  it('returns an empty string array if there is no .piidetectionignore file', async () => {
+    github.downloadContent = jest.fn(() => {
+      throw new HTTPError(404, 'Not Found')
+    })
+    const result = await getFilesToIgnore(IGNOREFILE)
+    expect(result).toEqual([])
+  })
+
+  it('throws an error if there was an error different than a 404 downloading the file', async () => {
+    github.downloadContent = jest.fn(() => {
+      throw new HTTPError(403, 'Forbidden')
+    })
+    await expect(getFilesToIgnore(IGNOREFILE)).rejects.toThrow()
+  })
+
+  it('returns a string array with the files to be ignored', async () => {
+    const ignorefile = `fake-customer-data.csv
+tests/some/dir/super-fake.csv
+`
+    const response = sampleDownloadFileResponse
+    response.content = Buffer.from(ignorefile).toString('base64')
+
+    mockGithub.downloadContent.mockResolvedValue(response as Content)
+
+    const result = await getFilesToIgnore(IGNOREFILE)
+    expect(result).toEqual([
+      'fake-customer-data.csv',
+      'tests/some/dir/super-fake.csv',
+    ])
+  })
+})
+
+describe('getCandidateFiles', () => {
+  it('throws an error if file argument is undefined', () => {
+    expect(() => getCandidateFiles(undefined, [])).toThrow()
+  })
+
+  it('returns an array with only the files that have files extensions to be scanned', () => {
+    const allFiles = [
+      { filename: 'customer-data.csv' },
+      { filename: 'fun-meme.jpeg' },
+    ]
+    const ignoreFiles = new Array<string>()
+
+    const result = getCandidateFiles(allFiles, ignoreFiles)
+    expect(result).toEqual([{ filename: 'customer-data.csv' }])
+  })
+
+  it('returns an array without files marked as to ignore', () => {
+    const allFiles = [
+      { filename: 'customer-data.csv' },
+      { filename: 'mocked-customer-data.csv' },
+    ]
+    const ignoreFiles = ['mocked-customer-data.csv']
+
+    const result = getCandidateFiles(allFiles, ignoreFiles)
+    expect(result).toEqual([{ filename: 'customer-data.csv' }])
+  })
+})
+
+describe('isFileExtensionToBeScanned', () => {
+  it('returns false if the file has an extension not to be scanned', () => {
+    expect(isFileExtensionToBeScanned('some/path/file.exe')).toBeFalsy()
+  })
+
+  it('returns true if the file has an extension to be scanned', () => {
+    expect(isFileExtensionToBeScanned('another/longer/path/results.csv')).toBe(
+      true
+    )
+  })
+})

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -67,17 +67,16 @@ const NotionPage =
 const piiDetection: Check = {
   name: 'pii-detection',
   async run(): Promise<boolean> {
-    let filesData
-    if (github.context.eventName === 'push') {
-      filesData = await downloadFilesDataFromPush()
-    } else if (github.context.eventName === 'pull_request') {
-      filesData = await downloadFilesDataFromPullRequest()
-    } else {
-      core.info(
+   if ( !['push', 'pull_request'].includes(github.context.eventName) ) {
+   core.info(
         'PII detection will only run on "push" and "pull_request" events. Skipping...'
       )
       return true
-    }
+}
+
+const filesData = github.context.eventName === 'push'
+       ? await downloadFilesDataFromPush()
+       : await downloadFilesDataFromPullRequest()
 
     const ignoreFiles = await getFilesToIgnore(Ignorefile)
 

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -67,16 +67,17 @@ const NotionPage =
 const piiDetection: Check = {
   name: 'pii-detection',
   async run(): Promise<boolean> {
-   if ( !['push', 'pull_request'].includes(github.context.eventName) ) {
-   core.info(
+    if (!['push', 'pull_request'].includes(github.context.eventName)) {
+      core.info(
         'PII detection will only run on "push" and "pull_request" events. Skipping...'
       )
       return true
-}
+    }
 
-const filesData = github.context.eventName === 'push'
-       ? await downloadFilesDataFromPush()
-       : await downloadFilesDataFromPullRequest()
+    const filesData =
+      github.context.eventName === 'push'
+        ? await downloadFilesDataFromPush()
+        : await downloadFilesDataFromPullRequest()
 
     const ignoreFiles = await getFilesToIgnore(Ignorefile)
 
@@ -130,7 +131,7 @@ async function downloadFilesDataFromPush(): Promise<FileData> {
 
 async function downloadFilesDataFromPullRequest(): Promise<FileData> {
   const pullPayload = github.context.payload as WebhookEventMap['pull_request']
-  return await github.getPullRequestFiles(pullPayload.pull_request.number)
+  return github.getPullRequestFiles(pullPayload.pull_request.number)
 }
 
 export function scanCsvForPii(
@@ -183,7 +184,9 @@ export async function downloadFileContent(
   ref?: string | undefined
 ): Promise<string> {
   const response = await github.downloadContent(filepath, ref)
-  if (!('content' in response)) throw new Error('No content in response')
+  if (!('content' in response)) {
+    throw new Error('No content in response')
+  }
 
   if (response.encoding === 'base64')
     return Buffer.from(response.content, 'base64').toString()
@@ -200,7 +203,9 @@ export async function getFilesToIgnore(
     ignoreFiles = content.split('\n').filter((line) => line.length > 0)
   } catch (e) {
     // Skipping error if the file added in the ignorefile doesn't exist (HTTP 404)
-    if (!e.status || (e.status && e.status !== 404)) throw e
+    if (!e.status || (e.status && e.status !== 404)) {
+      throw e
+    }
   }
 
   return ignoreFiles

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -189,10 +189,8 @@ export async function downloadFileContent(
   }
 
   return response.encoding === 'base64'
-     ? Buffer.from(response.content, 'base64').toString()
-     : response.content
-    return Buffer.from(response.content, 'base64').toString()
-  else return response.content
+    ? Buffer.from(response.content, 'base64').toString()
+    : response.content
 }
 
 export async function getFilesToIgnore(

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -188,7 +188,9 @@ export async function downloadFileContent(
     throw new Error('No content in response')
   }
 
-  if (response.encoding === 'base64')
+  return response.encoding === 'base64'
+     ? Buffer.from(response.content, 'base64').toString()
+     : response.content
     return Buffer.from(response.content, 'base64').toString()
   else return response.content
 }

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -61,7 +61,8 @@ const piiData: piiDataType[] = [
 const FileExtensionsToScan = ['.csv']
 export const Ignorefile = '.piidetectionignore'
 export const CsvDetectionThreshold = 0.7 // At least 70% of the CSV file lines must contain one of the detected data types
-const NotionPage = ''
+const NotionPage =
+  'https://www.notion.so/typeform/PII-Detection-Check-11658ceb312c49a69681d2507e750748'
 
 const piiDetection: Check = {
   name: 'pii-detection',

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -1,0 +1,239 @@
+import { Readable } from 'stream'
+
+import * as core from '@actions/core'
+import { WebhookEventMap } from '@octokit/webhooks-types'
+import { Endpoints } from '@octokit/types'
+import CsvReadableStream from 'csv-reader'
+
+import { github } from '../infrastructure/github'
+
+import Check from './check'
+
+type FileData =
+  Endpoints['GET /repos/{owner}/{repo}/commits/{ref}']['response']['data']['files']
+
+export type PiiDataTypeName =
+  | 'us-phone-number'
+  | 'email'
+  | 'ssn'
+  | 'credit-card-number'
+
+export type Prediction = {
+  detected: boolean
+  dataType?: PiiDataTypeName[]
+}
+
+export type piiDataType = {
+  type: PiiDataTypeName
+  regexp: RegExp
+}
+
+const piiData: piiDataType[] = [
+  {
+    type: 'us-phone-number',
+    regexp: new RegExp(
+      /^\+?(\d+)?[ .-]?\(?(\d{3})\)?[ .-]?(\d{3})[ .-]?(\d{4})$/i
+    ), // source https://gist.github.com/charles-rumley/e13b314662a203e5172a298bc66544b3
+  },
+  {
+    type: 'email',
+    regexp: new RegExp(/^[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+$/), // source https://ihateregex.io/expr/email
+  },
+  {
+    type: 'ssn',
+    regexp: new RegExp(
+      /^(?!0{3})(?!6{3})[0-8]\d{2}-(?!0{2})\d{2}-(?!0{4})\d{4}$/
+    ), // source https://ihateregex.io/expr/ssn/
+  },
+  {
+    type: 'credit-card-number',
+    regexp: new RegExp(
+      /^(^4[0-9]{12}(?:[0-9]{3})?$)|(^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$)|(3[47][0-9]{13})|(^3(?:0[0-5]|[68][0-9])[0-9]{11}$)|(^6(?:011|5[0-9]{2})[0-9]{12}$)|(^(?:2131|1800|35\d{3})\d{11}$)$/
+    ), // source https://ihateregex.io/expr/credit-card/
+  },
+]
+
+const FILE_EXTENSIONS_TO_SCAN = ['.csv']
+export const IGNOREFILE = '.piidetectionignore'
+export const CsvDetectionThreshold = 0.7 // At least 70% of the CSV file lines must contain one of the detected data types
+
+const piiDetection: Check = {
+  name: 'pii-detection',
+  async run(): Promise<boolean> {
+    // Depending on github.context.eventName (push or pull_request)
+    // the file will be downloaded differently:
+    // - push: getting the commit and then its files
+    // - pull_request: get head commit id and then its files
+
+    let filesData
+    if (github.context.eventName === 'push') {
+      filesData = await downloadFilesDataFromPush()
+    } else if (github.context.eventName === 'pull_request') {
+      filesData = await downloadFilesDataFromPullRequest()
+    } else {
+      core.info(
+        'PII detection will only run on "push" and "pull_request" events. Skipping...'
+      )
+      return true
+    }
+
+    const ignoreFiles = await getFilesToIgnore(IGNOREFILE)
+
+    const filesToBeScanned = getCandidateFiles(filesData, ignoreFiles)
+
+    if (!filesToBeScanned || filesToBeScanned.length === 0) {
+      core.info('No files to be scanned')
+      return true
+    }
+
+    const results: {
+      file: string
+      prediction: Prediction
+    }[] = []
+
+    core.info(`Scanning ${filesToBeScanned.length} files for PII`)
+    for (const file of filesToBeScanned) {
+      let content: string
+      try {
+        if (!file.contents_url) {
+          core.warning(`Unable to find file URL for ${JSON.stringify(file)}`)
+          continue
+        }
+
+        if (!file.filename) {
+          core.warning(`Unable to find file name for ${JSON.stringify(file)}`)
+          continue
+        }
+
+        const ref = file.contents_url.split('?ref=')[1]
+        content = await downloadFileContent(file.filename, ref)
+        // download file content to disk or memory??
+      } catch (e) {
+        core.error(`Error downloading ${file.filename}: ${e}`)
+        continue
+      }
+
+      const prediction = await scanCsvForPii(content, 0.7)
+      if (prediction.detected)
+        results.push({
+          file: file.filename,
+          prediction: prediction,
+        })
+    }
+
+    if (results.length === 0) {
+      return false
+    }
+
+    core.info(`${results.length} files detected with PII`)
+    return true
+  },
+}
+export default piiDetection
+
+async function downloadFilesDataFromPush(): Promise<FileData> {
+  const commitData = await github.getCommit(github.context.sha)
+  return commitData.files
+}
+
+async function downloadFilesDataFromPullRequest(): Promise<FileData> {
+  const pullPayload = github.context.payload as WebhookEventMap['pull_request']
+  return await github.getPullRequestFiles(pullPayload.pull_request.number)
+}
+
+export function scanCsvForPii(
+  content: string,
+  threshold: number
+): Promise<Prediction> {
+  let linesTotal = 0
+  const lineMatches: { [matchType: string]: number } = {}
+  for (const dataType of piiData) {
+    lineMatches[dataType.type] = 0
+  }
+
+  const prediction = new Promise<Prediction>((resolve, reject) => {
+    Readable.from(content)
+      .pipe(new CsvReadableStream({ trim: true, skipEmptyLines: true }))
+      .on('data', (line: string[]) => {
+        linesTotal++
+
+        for (const item of line) {
+          for (const dataType of piiData) {
+            if (dataType.regexp.test(item)) lineMatches[dataType.type]++
+          }
+        }
+      })
+      .on('error', (e) => {
+        reject(e)
+      })
+      .on('end', () => {
+        const p: Prediction = {
+          detected: false,
+          dataType: [],
+        }
+
+        for (const dataType of piiData) {
+          if (lineMatches[dataType.type] > linesTotal * threshold) {
+            p.detected = true
+            p.dataType?.push(dataType.type)
+          }
+        }
+
+        resolve(p)
+      })
+  })
+
+  return prediction
+}
+
+export async function downloadFileContent(
+  filepath: string,
+  ref?: string | undefined
+): Promise<string> {
+  const response = await github.downloadContent(filepath, github.context.ref)
+  if (!('content' in response)) throw new Error('No content in response')
+
+  if (response.encoding === 'base64')
+    return Buffer.from(response.content, 'base64').toString()
+  else return response.content
+}
+
+export async function getFilesToIgnore(
+  ignoreFile: string
+): Promise<Array<string>> {
+  let ignoreFiles: Array<string> = []
+
+  try {
+    const content = await downloadFileContent(ignoreFile, github.context.ref)
+    ignoreFiles = content.split('\n').filter((line) => line.length > 0)
+  } catch (e) {
+    // Skipping error if the file added in the ignorefile doesn't exist (HTTP 404)
+    if (!e.status || (e.status && e.status !== 404)) throw e
+  }
+
+  return ignoreFiles
+}
+
+export function getCandidateFiles(
+  files: FileData,
+  ignoreFiles: Array<string>
+): FileData {
+  if (!files) throw new Error('files is undefined')
+
+  const candidates = files.filter(
+    (f) =>
+      !(f.filename && ignoreFiles.includes(f.filename)) &&
+      isFileExtensionToBeScanned(f.filename || '')
+  )
+
+  return candidates
+}
+
+export function isFileExtensionToBeScanned(filename: string): boolean {
+  for (const ext of FILE_EXTENSIONS_TO_SCAN) {
+    if (filename.endsWith(ext)) {
+      return true
+    }
+  }
+  return false
+}

--- a/src/infrastructure/__mocks__/github.ts
+++ b/src/infrastructure/__mocks__/github.ts
@@ -9,4 +9,5 @@ export const github = {
   },
   getPullRequest: jest.fn(),
   getPullRequestsAssociatedWithCommit: jest.fn(),
+  downloadContent: jest.fn(),
 }

--- a/src/infrastructure/github.ts
+++ b/src/infrastructure/github.ts
@@ -9,6 +9,12 @@ export type PullsGetResponse =
   Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}']['response']['data']
 export type PullRequestsAssociatedWithCommitResponse =
   Endpoints['GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls']['response']['data']
+export type PullRequestFiles =
+  Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}/files']['response']['data']
+export type Content =
+  Endpoints['GET /repos/{owner}/{repo}/contents/{path}']['response']['data']
+export type Commit =
+  Endpoints['GET /repos/{owner}/{repo}/commits/{ref}']['response']['data']
 
 export class GitHub {
   context: Context
@@ -38,6 +44,34 @@ export class GitHub {
           previews: ['groot'],
         },
       })
+    return response.data
+  }
+
+  async getPullRequestFiles(pull_number: number): Promise<PullRequestFiles> {
+    const response = await this.octokit.rest.pulls.listFiles({
+      owner: this.context.repo.owner,
+      repo: this.context.repo.repo,
+      pull_number,
+    })
+    return response.data
+  }
+
+  async getCommit(ref: string): Promise<Commit> {
+    const response = await this.octokit.rest.repos.getCommit({
+      owner: this.context.repo.owner,
+      repo: this.context.repo.repo,
+      ref: ref,
+    })
+    return response.data
+  }
+
+  async downloadContent(path: string, ref?: string): Promise<Content> {
+    const response = await this.octokit.rest.repos.getContent({
+      owner: this.context.repo.owner,
+      repo: this.context.repo.repo,
+      path: path,
+      ref: ref,
+    })
     return response.data
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,6 +2105,11 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+csv-reader@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/csv-reader/-/csv-reader-1.0.8.tgz#2d1ee452550016aa3b3defea0339a209161eff21"
+  integrity sha512-EK03OmXoet2dljwfJoY7/M6C+DmsthQgObpXfO6yCQ2HKNVSBd9uQ3TDzlfbfDhSn8mgmnPR2oEUftip3VihTw==
+
 damerau-levenshtein@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz#64368003512a1a6992593741a09a9d31a836f55d"


### PR DESCRIPTION
On the Codecov incident the security team discovered that `.csv` files with Personal Identifiable Information (PII or "personal data") were uploaded to some repos. Uploading legit personal data to repos is not allowed as it conflicts with GDPR.

This PR adds a new check that will scan every new `.csv` file uploaded to a repo. The check does the following:

1. Scan the whole file using Regexp's that look for US phone numbers, emails, US social security numbers, and credit card numbers. This can be extended in a future.
2. If any of those Regexp's match more than `CsvDetectionThreshold` lines of the file, currently 70%, it is considered that the file contains PII.
3. If any file contains PII the check prints out the results and a Notion page URL with more info and it returns `false`.

As with the secrets detection check it is possible to force the check to not scan certain files. This can be done by adding a `.piidetectionignore` file in the root of the repo. This ignore file should include the path of the files to be ignored, one per line.

Now I'm working on the Notion page to include this same info and more details. What do you think?

