### PR TITLE
fix(SP-1221): throwing error when check does not pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ easier time rolling out new checks to teams. Win-win!
   again!
 - *secrets-scan*: make sure you're never ever ever commiting a secret to
   your repo. _Shhh, it's a secret_ :shushing_face:
+- *pii-detection*: make sure you're not uploading files with Personal Identifiable
+  Information to your repo.
 
 ## How to use it
 

--- a/src/checks/piiDetection.test.ts
+++ b/src/checks/piiDetection.test.ts
@@ -254,7 +254,7 @@ describe('printResultsAndExit', () => {
     expect(printResultsAndExit(results)).toBeTruthy()
   })
 
-  it('returns false if any of the predictions were positive', () => {
+  it('throws an error if any of the predictions were positive', () => {
     const results: PredictionResults = [
       {
         file: 'some-file.csv',
@@ -270,6 +270,6 @@ describe('printResultsAndExit', () => {
         },
       },
     ]
-    expect(printResultsAndExit(results)).toBeFalsy()
+    expect(() => printResultsAndExit(results)).toThrow()
   })
 })

--- a/src/checks/piiDetection.ts
+++ b/src/checks/piiDetection.ts
@@ -257,20 +257,23 @@ export function printResultsAndExit(results: PredictionResults): boolean {
     return shouldCheckPass
   }
 
+  let errorMessage = ''
   for (const r of results) {
     if (!r.prediction.detected) continue
 
     if (r.prediction.dataType && r.prediction.dataType.length > 0) {
       shouldCheckPass = false
-      core.info(
-        `The file ${r.file} contains ${r.prediction.dataType.toString()}`
-      )
+      errorMessage += `The file ${
+        r.file
+      } contains ${r.prediction.dataType.toString()}\n`
     }
   }
 
-  if (!shouldCheckPass)
-    core.info(`Looks like one or more files contain Personal Identifiable Information (PII) or it's a false positive.
-Check out this Notion page to know what to do next ${NotionPage}`)
+  if (!shouldCheckPass) {
+    errorMessage += `Looks like one or more files contain Personal Identifiable Information (PII) or it's a false positive.\n`
+    errorMessage += `Check out this Notion page to know what to do next ${NotionPage}\n`
+    throw new Error(errorMessage)
+  }
 
   return shouldCheckPass
 }


### PR DESCRIPTION
From the repo's `README.md`:

> To make your check pass, return a value. To make it fail, throw an Error. The error message will be caught and printed to the action output.