### PR TITLE
feat(SP-1744): update to gitleaks v8

### DIFF
--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -55,6 +55,9 @@ else
     echo "Retrieving PR#$pull_number commits info from ${PR_URL}"
     curl -H "Authorization: Bearer ${GITHUBTOKEN}" $PR_URL > $tmp_dir/commit_list.json
     cat $tmp_dir/commit_list.json | jq 'map(.sha)' | jq '.[]' | sed -r 's/"//g' > $commits_file
+    echo "commits file"
+    cat $commits_file
+    echo "---"
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
 
     commit_opts="--log-opts=${commits_file}"

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    commit_opts="--log-opts=${GITHUB_SHA}"
+    commit_opts="--log-opts=${GITHUB_SHA}..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -59,8 +59,9 @@ else
     cat $commits_file
     echo "---"
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
-
-    commit_opts="--log-opts=${commits_file}"
+    base_ref=$(head $commits_file)
+    head_ref=$(tail $commits_file)
+    commit_opts="--log-opts=$base_ref..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -34,13 +34,14 @@ commits_file="$tmp_dir/commit_list.txt"
 gitleaks_config_container="${DOCKERREGISTRY}/typeform/gitleaks-config"
 gitleaks_container="zricethezav/gitleaks"
 gitleaks_version="v8.8.8"
+gitleaks_config_cmd="python gitleaks_config_generator.py --v8-config"
 
 # Generate the final gitleaks config file. If the repo has a local config, merge both
 if [ -f ./"$local_config" ]; then
     docker container run --rm -v $repo_dir/$local_config:/app/$local_config \
-    $gitleaks_config_container "--v8-config" > $final_config
+    $gitleaks_config_container $gitleaks_config_cmd > $final_config
 else
-    docker container run --rm $gitleaks_config_container "--v8-config" > $final_config
+    docker container run --rm $gitleaks_config_container $gitleaks_config_cmd > $final_config
 fi
 
 if [ -z "${GITHUB_BASE_REF}" ]; then

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -55,9 +55,6 @@ else
     echo "Retrieving PR#$pull_number commits info from ${PR_URL}"
     curl -H "Authorization: Bearer ${GITHUBTOKEN}" $PR_URL > $tmp_dir/commit_list.json
     cat $tmp_dir/commit_list.json | jq 'map(.sha)' | jq '.[]' | sed -r 's/"//g' > $commits_file
-    echo "commits file"
-    cat $commits_file
-    echo "---"
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head $commits_file)
     head_ref=$(tail $commits_file)

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    commit_opts="--commit=${GITHUB_SHA}"
+    commit_opts="--log-opts=${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -57,7 +57,7 @@ else
     cat $tmp_dir/commit_list.json | jq 'map(.sha)' | jq '.[]' | sed -r 's/"//g' > $commits_file
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
 
-    commit_opts="--commits-file=${commits_file}"
+    commit_opts="--log-opts=${commits_file}"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.


### PR DESCRIPTION
This PR updates the tool `gitleaks` used in the secrets detection check to its latest major version.

`gitleaks` API and exception file for every repo (`.gitleaks.toml`) is broken with this new version. So, the migration plan I have in mind is the following:
1. Merge this into `ci-standard-checks@v1-beta`
2. Test secrets detection in repos that use `ci-standard-checks@v1-beta`
3. Submit PRs to all repos that have a `.gitleaks.toml` file and use `ci-standard-checks@v1`. The PR will update `.gitleaks.toml` to make it compatible with `gitleaks` version 8 and also make the repos use `ci-standard-checks@v1-beta`
4. Once all PRs from previous step are merged, promote `ci-standard-checks@v1-beta` to `ci-standard-checks@v1` and submit PRs to the same repos to make them use `ci-standard-checks@v1` instead of `ci-standard-checks@v1-beta`

Maybe there's a better migration plan, let me know what you think. Thanks!
