### PR TITLE
chore(SP-1745): using new gitleaks v8 configuration file format

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,3 @@
 [allowlist]
-  files = ["README.md"]
+  paths = ["README.md"]
   regexes = ['''ullRequestsAssociatedWithCommit''']


### PR DESCRIPTION
This PR generated by SourceGraph updates the `.gitleaks.toml` file format to be compatible with gitleaks v8.

This repo is using `ci-standard-checks@v1-beta` which [has been updated to use the latest gitleaks v8](https://github.com/Typeform/ci-standard-checks/pull/119).

[_Created by Sourcegraph batch change `david.salvador/update-gitleaks-config-to-v8-in-v1beta`._](https://sourcegraph.tools.typeform.tf/users/david.salvador/batch-changes/update-gitleaks-config-to-v8-in-v1beta)