### PR TITLE
fix(SP-1936): base commit not being secret scanned

### DIFF
--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -58,7 +58,8 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="--first-parent --no-merges $base_ref^..$head_ref"
+    #log_opts="--first-parent --no-merges $base_ref^..$head_ref"
+    log_opts="$base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -71,7 +72,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=\"${log_opts}\" \
+    --log-opts=${log_opts} \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -75,7 +75,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=\"${log_opts}\" \
+    --log-opts=${log_opts} \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="--no-merges --invalid-option $base_ref^..$head_ref"
+    log_opts="--no-merges $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -71,7 +71,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=${log_opts} \
+    --log-opts='${log_opts}' \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    log_opts="${GITHUB_SHA}^..${GITHUB_SHA}"
+    log_opts="--no-merges --first-parent ${GITHUB_SHA}^..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="$base_ref^..$head_ref"
+    log_opts="--no-merges --first-parent $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -71,8 +71,8 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=\"${log_opts}\" \
-    --verbose"
+    --verbose \
+    --log-opts=${log_opts}"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,9 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    log_opts="--first-parent --no-merges ${GITHUB_SHA}^..${GITHUB_SHA}"
+    # not including --first-parent and --no-merges until https://github.com/zricethezav/gitleaks/issues/964 is fixed
+    #log_opts="--first-parent --no-merges ${GITHUB_SHA}^..${GITHUB_SHA}"
+    log_opts="${GITHUB_SHA}^..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,9 +60,9 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    merge_opts="--first-parent --no-merges "
-    log_opts="${merge_opts}${base_ref}^..${head_ref}"
-    #log_opts="$base_ref^..$head_ref"
+    # not including --first-parent and --no-merges until https://github.com/zricethezav/gitleaks/issues/964 is fixed
+    #log_opts="--first-parent --no-merges ${base_ref}^..${head_ref}"
+    log_opts="${base_ref}^..${head_ref}"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -75,7 +77,7 @@ gitleaks_cmd="detect \
     --report-format=json \
     --log-opts=\"${log_opts}\" \
     --verbose"
-echo ${gitleaks_cmd}
+echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \
     -v $commits_file:$commits_file \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -71,7 +71,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=\"${log_opts}\" \
+    --log-opts=${log_opts} \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -75,7 +75,7 @@ gitleaks_cmd="detect \
     --report-format=json \
     --log-opts=\"${log_opts}\" \
     --verbose"
-echo "${gitleaks_cmd}"
+echo ${gitleaks_cmd}
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \
     -v $commits_file:$commits_file \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -71,12 +71,12 @@ set +e
 echo "Using gitleaks${gitleaks_version}"
 
 # Run gitleaks with the generated config
-gitleaks_cmd="detect \
+gitleaks_cmd='detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
     --log-opts=\"${log_opts}\" \
-    --verbose"
+    --verbose'
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    commit_opts='--log-opts="--no-merges --first-parent ${GITHUB_SHA}..${GITHUB_SHA}"'
+    commit_opts="--log-opts=\"--no-merges --first-parent ${GITHUB_SHA}..${GITHUB_SHA}\""
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    commit_opts='--log-opts="--no-merges --first-parent $base_ref^..$head_ref"'
+    commit_opts="--log-opts=\"--no-merges --first-parent $base_ref^..$head_ref\""
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -73,7 +73,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=${log_opts} \
+    --log-opts="${log_opts}" \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="--no-merges $base_ref^..$head_ref"
+    log_opts="--no-merges --invalid-option $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -71,7 +71,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts='${log_opts}' \
+    --log-opts='$log_opts' \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    commit_opts="--log-opts=$base_ref~1..$head_ref"
+    commit_opts="--log-opts=--no-merges --first-parent $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    commit_opts="--log-opts=$base_ref..$head_ref"
+    commit_opts="--log-opts=$base_ref~1..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    commit_opts="--log-opts=${GITHUB_SHA}..${GITHUB_SHA}"
+    commit_opts='--log-opts="--no-merges --first-parent ${GITHUB_SHA}..${GITHUB_SHA}"'
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    commit_opts="--log-opts=--no-merges --first-parent $base_ref^..$head_ref"
+    commit_opts='--log-opts="--no-merges --first-parent $base_ref^..$head_ref"'
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    log_opts="--no-merges --first-parent ${GITHUB_SHA}^..${GITHUB_SHA}"
+    log_opts="--no-merges ${GITHUB_SHA}^..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="--no-merges --first-parent $base_ref^..$head_ref"
+    log_opts="--no-merges $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -67,7 +67,12 @@ set +e
 echo "Using gitleaks${gitleaks_version}"
 
 # Run gitleaks with the generated config
-gitleaks_cmd="detect --config=${final_config} --source=/tmp/${repo_name} --report-format=json --log-opts=\"${log_opts}\" --verbose"
+gitleaks_cmd="detect \
+    --config=${final_config} \
+    --source=/tmp/${repo_name} \
+    --report-format=json \
+    --log-opts=\"${log_opts}\" \
+    --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -73,6 +73,7 @@ gitleaks_cmd="detect \
     --report-format json \
     --log-opts=\"${log_opts}\" \
     --verbose"
+echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \
     -v $commits_file:$commits_file \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -68,9 +68,9 @@ echo "Using gitleaks${gitleaks_version}"
 
 # Run gitleaks with the generated config
 gitleaks_cmd="detect \
-    --config ${final_config} \
-    --source /tmp/${repo_name} \
-    --report-format json \
+    --config=${final_config} \
+    --source=/tmp/${repo_name} \
+    --report-format=json \
     --log-opts=\"${log_opts}\" \
     --verbose"
 echo "${gitleaks_cmd}"

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -73,7 +73,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts="${log_opts}" \
+    --log-opts=\"${log_opts}\" \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    log_opts="--no-merges ${GITHUB_SHA}^..${GITHUB_SHA}"
+    log_opts="${GITHUB_SHA}^..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="--no-merges $base_ref^..$head_ref"
+    log_opts="$base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -71,7 +71,7 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts='$log_opts' \
+    --log-opts=\"${log_opts}\" \
     --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -71,7 +71,7 @@ gitleaks_cmd="detect \
     --config ${final_config} \
     --source /tmp/${repo_name} \
     --report-format json \
-    --log-opts=${log_opts} \
+    --log-opts=\"${log_opts}\" \
     --verbose"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -75,7 +75,7 @@ gitleaks_cmd='detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts=\"${log_opts}\" \
+    --log-opts="${log_opts}" \
     --verbose'
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -67,12 +67,7 @@ set +e
 echo "Using gitleaks${gitleaks_version}"
 
 # Run gitleaks with the generated config
-gitleaks_cmd="detect \
-    --config=${final_config} \
-    --source=/tmp/${repo_name} \
-    --report-format=json \
-    --log-opts=\"${log_opts}\" \
-    --verbose"
+gitleaks_cmd="detect --config=${final_config} --source=/tmp/${repo_name} --report-format=json --log-opts=\"${log_opts}\" --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -58,8 +58,9 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    #log_opts="--first-parent --no-merges $base_ref^..$head_ref"
-    log_opts="$base_ref^..$head_ref"
+    merge_opts="--first-parent --no-merges "
+    log_opts="${merge_opts}${base_ref}^..${head_ref}"
+    #log_opts="$base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -71,12 +71,12 @@ set +e
 echo "Using gitleaks${gitleaks_version}"
 
 # Run gitleaks with the generated config
-gitleaks_cmd='detect \
+gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --log-opts="${log_opts}" \
-    --verbose'
+    --log-opts=\"${log_opts}\" \
+    --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    commit_opts="--log-opts=\"--no-merges --first-parent ${GITHUB_SHA}..${GITHUB_SHA}\""
+    log_opts="--no-merges --first-parent ${GITHUB_SHA}^..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    commit_opts="--log-opts=\"--no-merges --first-parent $base_ref^..$head_ref\""
+    log_opts="--no-merges --first-parent $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -71,7 +71,7 @@ gitleaks_cmd="detect \
     --config ${final_config} \
     --source /tmp/${repo_name} \
     --report-format json \
-    ${commit_opts} \
+    --log-opts=${log_opts} \
     --verbose"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -47,7 +47,7 @@ fi
 if [ -z "${GITHUB_BASE_REF}" ]; then
     # push event
     echo "Using commit SHA ${GITHUB_SHA} for push event"
-    log_opts="--no-merges --first-parent ${GITHUB_SHA}^..${GITHUB_SHA}"
+    log_opts="--first-parent --no-merges ${GITHUB_SHA}^..${GITHUB_SHA}"
 else
     # pull_request event
     pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -58,7 +58,7 @@ else
     echo "$(cat $commits_file | wc -l | sed -r 's/ //g') commits found in PR#$pull_number"
     base_ref=$(head -n1 $commits_file)
     head_ref=$(tail -n1 $commits_file)
-    log_opts="--no-merges --first-parent $base_ref^..$head_ref"
+    log_opts="--first-parent --no-merges $base_ref^..$head_ref"
 fi
 
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
@@ -71,8 +71,8 @@ gitleaks_cmd="detect \
     --config=${final_config} \
     --source=/tmp/${repo_name} \
     --report-format=json \
-    --verbose \
-    --log-opts=${log_opts}"
+    --log-opts=\"${log_opts}\" \
+    --verbose"
 echo "${gitleaks_cmd}"
 docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \


### PR DESCRIPTION
As per [gitleaks documentation](https://github.com/zricethezav/gitleaks):
>When running detect on a git repository, gitleaks will parse the output of a git log -p command (you can see how this executed [here](https://github.com/zricethezav/gitleaks/blob/7240e16769b92d2a1b137c17d6bf9d55a8562899/git/git.go#L17-L25)). git log -p[ generates patches](https://git-scm.com/docs/git-log#_generating_patch_text_with_p) which gitleaks will use to detect secrets.

And, [because of an issue with false positives](https://typeform.slack.com/archives/CCWDN8ASJ/p1660895849830629?thread_ts=1659448611.368089&cid=CCWDN8ASJ), we discovered that when running `git log -p $base..$head` the `$base` commit is not included in the output because the interval is not inclusive on the left operand (a `git` feature).

This PR fixes this by including the previous commit to `$base`.

Edit:
Using [gitleaks Github Action](https://github.com/gitleaks/gitleaks-action/blob/6b27c02ab47f7b595ce9890edd12ae7cd9101ab2/src/gitleaks.js#L115) as reference, I'm adding the following to the `git log` opts:
* `^` to make the left operand in `$commitA..commitB` inclusive
* ~`--no-merges` and `--first-parent` to avoid issues and unnecessary scans in rebased PRs~ See Edit 2

Edit 2:
Looks like there's something wrong when adding multiple parameters in `--log-opts`. I've opened [an issue in gitleaks](https://github.com/zricethezav/gitleaks/issues/964). Until that is resolved, we'll skip those two flags (`--no-merges` and `--first-parent`).