### PR TITLE
fix(openapi): change redocly package name and add a config file

### DIFF
--- a/scripts/validate-openapi/.redocly.yaml
+++ b/scripts/validate-openapi/.redocly.yaml
@@ -1,6 +1,0 @@
-styleguide:
-  extends:
-    - recommended
-  rules:
-    operation-4xx-response: off
-    security-defined: warn

--- a/scripts/validate-openapi/.redocly.yaml
+++ b/scripts/validate-openapi/.redocly.yaml
@@ -1,0 +1,6 @@
+styleguide:
+  extends:
+    - recommended
+  rules:
+    operation-4xx-response: off
+    security-defined: warn

--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -32,10 +32,10 @@ then
     exit 1
 fi
 
-npx @redocly/openapi-cli bundle --dereferenced openapi.yaml > openapi.der.yaml
+npx @redocly/cli bundle --dereferenced openapi.yaml > openapi.der.yaml
 
 npx @apidevtools/swagger-cli validate openapi.yaml
 
 npx @apidevtools/swagger-cli validate openapi.der.yaml
 
-npx @redocly/openapi-cli lint openapi.yaml openapi.der.yaml
+npx @redocly/cli lint openapi.yaml openapi.der.yaml

--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -41,11 +41,8 @@ rules:
   security-defined: warn
 EOF
 
-echo "#cli bundle"
-npx @redocly/cli bundle --dereferenced openapi.yaml > openapi.der.yaml
-echo "#swagger validate openapi"
 npx @apidevtools/swagger-cli validate openapi.yaml
-echo "#swagger validate openapi.der"
-npx @apidevtools/swagger-cli validate openapi.der.yaml
-echo "#cli lint"
-npx @redocly/cli lint openapi.yaml openapi.der.yaml
+
+npx @redocly/cli lint openapi.yaml
+
+npx @redocly/cli bundle --dereferenced --ext json --output openapi.json openapi.yaml

--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -32,10 +32,20 @@ then
     exit 1
 fi
 
+# Create redocly config file
+cat > .redocly.yaml << EOF
+extends:
+  - recommended
+rules:
+  operation-4xx-response: off
+  security-defined: warn
+EOF
+
+echo "#cli bundle"
 npx @redocly/cli bundle --dereferenced openapi.yaml > openapi.der.yaml
-
+echo "#swagger validate openapi"
 npx @apidevtools/swagger-cli validate openapi.yaml
-
+echo "#swagger validate openapi.der"
 npx @apidevtools/swagger-cli validate openapi.der.yaml
-
+echo "#cli lint"
 npx @redocly/cli lint openapi.yaml openapi.der.yaml


### PR DESCRIPTION
### Description

Update the redocly package name (old one is deprecated) and add a new config file (soon to be required) to match the api-docs repository config

⚠️ It has been tested in forms-api and toltec

### Changes
- Change package name
- Add configuration file
