### PR TITLE
chore(WEB-5102): set node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: true
     description: 'The docker password with access to Typeform gitleaks image'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
We are getting a warning from `ci-standard-checks` about the node version:

> [ci-standard-checks](https://github.com/Typeform/public-main-site/actions/runs/3280777332/jobs/5401976950)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, Typeform/ci-standard-checks, actions/checkout

You can see the annotation warning here: https://github.com/Typeform/public-main-site/actions/runs/3280777332

This PR is setting a new version for node.