### PR TITLE
[SS-1865] multiple openapi files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ will be published and a new release will happen automatically! :rocket:
 ## Validate
 
 There's a [test.yml](.github/workflows/test.yml) workflow in the repo
-referencing `./` to test the acion itself. This will be run to
+referencing `./` to test the action itself. This will be run to
 validate every PR. :white_check_mark:
 
 See the [actions

--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -41,8 +41,14 @@ rules:
   security-defined: warn
 EOF
 
-npx @apidevtools/swagger-cli validate openapi.yaml
+IFS=$'\n' files=($(find . -name openapi.yaml))
 
-npx @redocly/cli lint openapi.yaml
+for f in ${files[@]}; do
+    npx @apidevtools/swagger-cli validate "$f"
+done
 
-npx @redocly/cli bundle --dereferenced --ext json --output openapi.json openapi.yaml
+for f in ${files[@]}; do
+    npx @redocly/cli lint "$f"
+done
+
+npx @redocly/cli bundle --dereferenced --ext json --output openapi.json $(echo ${files})

--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -41,7 +41,8 @@ rules:
   security-defined: warn
 EOF
 
-IFS=$'\n' files=($(find . -name openapi.yaml))
+# Limiting the depth limits the risk of (irrelevant) `openapi.yaml` files being found in eg. `_gomodcache` or `node_modules`
+IFS=$'\n' files=($(find . -depth 3 -name openapi.yaml))
 
 for f in ${files[@]}; do
     npx @apidevtools/swagger-cli validate "$f"


### PR DESCRIPTION
In some cases, such as serverless-based services exposing their API as a
set of functions, each with its own hostname, more than one
`openapi.yaml` file may be needed to document a service's full API.

The adds supports for multiple `openapi.yaml`
files to the openAPI validation script, validating, linting and bundling all of them.