### PR TITLE
Fix `find` syntax in openAPI validation

### DIFF
--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -42,7 +42,7 @@ rules:
 EOF
 
 # Limiting the depth limits the risk of (irrelevant) `openapi.yaml` files being found in eg. `_gomodcache` or `node_modules`
-IFS=$'\n' files=($(find . -depth 3 -name openapi.yaml))
+IFS=$'\n' files=($(find . -maxdepth 3 -name openapi.yaml))
 
 for f in ${files[@]}; do
     npx @apidevtools/swagger-cli validate "$f"


### PR DESCRIPTION
Fix `find` syntax in openAPI validation

A bug was introduced by a previous commit: `find`'s `-depth` argument
causes a depth-first search to be performed, instead of limiting search
depth as intended. This commit hence uses `-maxdepth` instead.

Tested by @jordiroig-tf via [this job](https://github.com/Typeform/auth-api/actions/runs/3830507410).