### PR TITLE
feat(SP-2174): adding typeform-security org

### DIFF
--- a/src/conditions/belongsToTypeformOrg.test.ts
+++ b/src/conditions/belongsToTypeformOrg.test.ts
@@ -20,6 +20,15 @@ describe('outsideTypeformOrg', () => {
     await expect(belongsToTypeformOrg()).resolves.toBeTruthy()
   })
 
+  it('returns true when repo owned by typeform-security', async () => {
+    mockContext.repo = {
+      owner: 'typeform-security',
+      repo: 'security-infra',
+    }
+
+    await expect(belongsToTypeformOrg()).resolves.toBeTruthy()
+  })
+
   it('returns false when repo owned by someone else', async () => {
     mockContext.repo = {
       owner: 'SomeRandomPerson',

--- a/src/conditions/belongsToTypeformOrg.ts
+++ b/src/conditions/belongsToTypeformOrg.ts
@@ -1,5 +1,8 @@
 import { github } from '../infrastructure/github'
 
 export async function belongsToTypeformOrg(): Promise<boolean> {
-  return github.context.repo.owner === 'Typeform'
+  return (
+    github.context.repo.owner === 'Typeform' ||
+    github.context.repo.owner === 'typeform-security'
+  )
 }


### PR DESCRIPTION
Certain repositories are stored in a different Github organization named `typeform-security`. Checks like Secrets Detection and PII Detection are very important to have there too.