### PR TITLE
feat(SP-2214): upgrade gitleaks version

### DIFF
--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -31,7 +31,7 @@ final_config="$tmp_dir/gitleaks_config.toml"
 commits_file="$tmp_dir/commit_list.txt"
 gitleaks_config_container="${DOCKERREGISTRY}/typeform/gitleaks-config"
 gitleaks_container="zricethezav/gitleaks"
-gitleaks_version="v8.8.8"
+gitleaks_version="v8.16.1"
 gitleaks_config_cmd="python gitleaks_config_generator.py"
 
 # Generate the final gitleaks config file. If the repo has a local config, merge both


### PR DESCRIPTION
This PR bumps the `gitleaks` version. This is needed to use the `extend` feature which reduces complexity of the rules file, more info in [SP-2214](https://typeform.atlassian.net/browse/SP-2214).

[SP-2214]: https://typeform.atlassian.net/browse/SP-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ