### PR TITLE
chore(SP-1664): remove docker credentials

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -22,5 +22,3 @@ jobs:
         uses: Typeform/ci-standard-checks@v1-beta
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          dockerUsername: ${{ secrets.GITLEAKS_DOCKER_USERNAME }}
-          dockerPassword: ${{ secrets.GITLEAKS_DOCKER_PASSWORD }}


### PR DESCRIPTION
This PR removes Docker credentials from `ci-standard-checks` as they are not needed anymore since [we're using a public image for the secrets detection configuration](https://github.com/Typeform/ci-standard-checks/blob/main/scripts/secrets-scan/run.sh#L13-L14).
