### PR TITLE
fix(SP-2457): private or public runner check

### DIFF
--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -11,8 +11,10 @@ get_gitleaks_container() {
 
     # Based on https://gist.github.com/outofcoffee/8f40732aefacfded14cce8a45f6e5eb1
     echo "running aws ecr describe images"
+    set -x
     aws ecr describe-images --repository-name=${mirror_repo_name} --image-ids=${image_ids} --registry-id=${registry_id}
     exit_code=$?
+    set +x
 
     if [ $exit_code -eq 0 ]; then
         echo $mirrored_gitleaks

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -12,11 +12,7 @@ get_gitleaks_container() {
     public_gitleaks=${repo_name}
 
     # Based on https://gist.github.com/outofcoffee/8f40732aefacfded14cce8a45f6e5eb1
-    echo "running aws ecr describe images"
-    set -x
-    aws ecr describe-images --repository-name=${mirror_repo_name} --image-ids=${image_ids} --registry-id=${registry_id}
-    exit_code=$?
-    set +x
+    aws ecr describe-images --repository-name=${mirror_repo_name} --image-ids=${image_ids} --registry-id=${registry_id} &>/dev/null
 
     if [ $exit_code -eq 0 ]; then
         echo $mirrored_gitleaks

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -13,6 +13,7 @@ get_gitleaks_container() {
 
     # Based on https://gist.github.com/outofcoffee/8f40732aefacfded14cce8a45f6e5eb1
     aws ecr describe-images --repository-name=${mirror_repo_name} --image-ids=${image_ids} --registry-id=${registry_id} &>/dev/null
+    exit_code=$?
 
     if [ $exit_code -eq 0 ]; then
         echo $mirrored_gitleaks

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+GITLEAKS_VERSION="v8.16.1"
+
 get_gitleaks_container() {
     repo_name="zricethezav/gitleaks"
     mirror_repo_name="mirror/${repo_name}"
-    image_ids="imageTag=${gitleaks_version}"
+    image_ids="imageTag=${GITLEAKS_VERSION}"
     registry_id="567716553783"
 
     mirrored_gitleaks="${registry_id}.dkr.ecr.us-east-1.amazonaws.com/${mirror_repo_name}"
@@ -56,7 +58,6 @@ final_config="$tmp_dir/gitleaks_config.toml"
 commits_file="$tmp_dir/commit_list.txt"
 gitleaks_config_container="${DOCKERREGISTRY}/typeform/gitleaks-config"
 gitleaks_container=$(get_gitleaks_container)
-gitleaks_version="v8.16.1"
 gitleaks_config_cmd="python gitleaks_config_generator.py"
 
 # Generate the final gitleaks config file. If the repo has a local config, merge both
@@ -91,7 +92,7 @@ fi
 # Do not exit if the gitleaks run fails. This way we can display some custom messages.
 set +e
 
-echo "Using the following gitleaks container image: ${gitleaks_container}:${gitleaks_version}"
+echo "Using the following gitleaks container image: ${gitleaks_container}:${GITLEAKS_VERSION}"
 
 # Run gitleaks with the generated config
 gitleaks_cmd="detect \
@@ -105,7 +106,7 @@ docker container run --rm --name=gitleaks \
     -v $final_config:$final_config \
     -v $commits_file:$commits_file \
     -v $repo_dir:/tmp/$repo_name \
-    $gitleaks_container:$gitleaks_version ${gitleaks_cmd}
+    $gitleaks_container:$GITLEAKS_VERSION ${gitleaks_cmd}
 
 # Keep the exit code of the gitleaks run
 exit_code=$?

--- a/scripts/secrets-scan/run.sh
+++ b/scripts/secrets-scan/run.sh
@@ -10,7 +10,8 @@ get_gitleaks_container() {
     public_gitleaks=${repo_name}
 
     # Based on https://gist.github.com/outofcoffee/8f40732aefacfded14cce8a45f6e5eb1
-    aws ecr describe-images --repository-name=${mirror_repo_name} --image-ids=${image_ids} --registry-id=${registry_id} &>/dev/null
+    echo "running aws ecr describe images"
+    aws ecr describe-images --repository-name=${mirror_repo_name} --image-ids=${image_ids} --registry-id=${registry_id}
     exit_code=$?
 
     if [ $exit_code -eq 0 ]; then


### PR DESCRIPTION
This PR fixes a variable scoping error in the secrets detection script that made the private or public runner check always return public. Thus, making Docker rate limit us again.