### PR TITLE
fix: bump redocly/cli

### DIFF
--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -39,13 +39,15 @@ extends:
 rules:
   operation-4xx-response: off
   security-defined: warn
+  no-identical-paths: warn
+  operation-parameters-unique: warn
 EOF
 
 # Limiting the depth limits the risk of (irrelevant) `openapi.yaml` files being found in eg. `_gomodcache` or `node_modules`
 IFS=$'\n' files=($(find . -maxdepth 3 -name openapi.yaml))
 
 for f in ${files[@]}; do
-    npx @redocly/cli@1.0.2 lint --extends=minimal "$f"
+    npx @redocly/cli lint "$f"
 done
 
-npx @redocly/cli@1.0.2 bundle --dereferenced --ext json --output openapi.json $(echo ${files})
+npx @redocly/cli bundle --dereferenced --ext json --output openapi.json $(echo ${files})


### PR DESCRIPTION
we found out that ci-standard-checks and api-docs are using different versions of `redocly/cli`. This means that the openapi validation done through the standard checks does not match the one done by apidocs. 

This is likely due to the fact that the configs used are different.
 
 ## Changes
 1. modify the redocly config rules, adding two missing rules that api-docs has.
 2. remove `--extends=minimal` so it uses `recommended` which is what the redocly config has. (and apidocs)
 3. unpin the version from `npx @redocly/cli@1.0.2 lint --extends=minimal "$f"` so it uses the latest available (as apidocs does)