### PR TITLE
chore(CODEOWNERS): same owners for api-docs and ci-standard-check

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @Typeform/delivery-experience
 
-scripts/validate-openapi  @Typeform/engineering-community
+/scripts/validate-openapi/  @Typeform/engineering-community

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 * @Typeform/delivery-experience
+
+scripts/validate-openapi  @Typeform/engineering-community


### PR DESCRIPTION
As api-docs is owned by engineering community, this check should be, too.