### PR TITLE
feat(TU-26042): switch redocly bundle to yaml format

### DIFF
--- a/scripts/validate-openapi/run.sh
+++ b/scripts/validate-openapi/run.sh
@@ -50,4 +50,4 @@ for f in ${files[@]}; do
     npx @redocly/cli lint "$f"
 done
 
-npx @redocly/cli bundle --dereferenced --ext json --output openapi.json $(echo ${files})
+npx @redocly/cli bundle --dereferenced --ext yaml --output openapi.json $(echo ${files})


### PR DESCRIPTION
This allows support for openapi specs that use circular references (such as forms-api's Fields property).

`redocly` does not have the ability to control circular references when bundling the spec in JSON format.

`api-docs`'s CI using a [transformation](https://github.com/Typeform/api-docs/pull/801) to resolve this problem.

However, repos that reference the published components, that are generated by api-docs, will still be faced with the circular reference (e.g. https://typeform.design/api-docs/schema/Field.yaml).

`api-docs`'s CI is solely responsible for generating the "official" `openapi.json` spec bundle. It downloads all the `openapi.yaml` files from the other API repos and bundles them with the common models defined in `api-docs`.

The `validate-openapi` step of the `ci-standard-checks` action exists as an early detection of potential spec bundling issues that `api-docs`'s CI could face. It is solely a check. While this PR changes the output format to YAML will not affect the CI executed by `api-docs`, not will it change its JSON format.
