### PR TITLE
fix(PLT-3359): harden yarn configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 updates:
   - package-ecosystem: npm
     schedule:
@@ -13,7 +12,14 @@ updates:
       - "/"
     commit-message:
       prefix: fix(dependabot)
-
+    cooldown:
+      default-days: 7
+      exclude:
+        - '@typeform/*'
+    ignore:
+      - dependency-name: semantic-release
+        versions:
+          - '>=25.0.0'
   - package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 updates:
   - package-ecosystem: npm
     schedule:
@@ -13,7 +12,11 @@ updates:
       - "/"
     commit-message:
       prefix: fix(dependabot)
-
+    cooldown:
+      default:
+        days: 7
+      exclude-patterns:
+        - "@typeform/*"
   - package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+ignore-scripts true
+save-exact true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+ignore-scripts true   # blocks all postinstall scripts
+save-exact true       # forces exact pins on yarn add


### PR DESCRIPTION
## Harden yarn configuration
This PR hardens yarn configuration against supply chain attacks.

### Changes
- **`.yarnrc`**: Added `ignore-scripts true` and `save-exact true`.
- **Dependabot**: Added a 7-day `cooldown` for third-party npm updates (excluding `@typeform/*`).
- **Compatibility**: Maintained `semantic-release` version locks for Node 22 compatibility.

---
_Automated by Application Security · supply-chain-hardening_

[_Created by Sourcegraph batch change `david.salvador/harden-yarn-config`._](https://typeform.sourcegraphcloud.com/users/david.salvador/batch-changes/harden-yarn-config)