### PR TITLE
chore: align dependabot config with Typeform standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.GH_TOKEN }}
+  git-github:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: '${{ secrets.GH_TOKEN }}'
+
 updates:
   - package-ecosystem: npm
     schedule:
@@ -13,6 +24,13 @@ updates:
       - "/"
     commit-message:
       prefix: fix(dependabot)
+    registries:
+      - npm-github
+      - git-github
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@typeform/*"
 
   - package-ecosystem: github-actions
     schedule:
@@ -26,3 +44,5 @@ updates:
       - "/"
     commit-message:
       prefix: build(dependabot)
+    registries:
+      - git-github


### PR DESCRIPTION
## Summary

Aligns `.github/dependabot.yml` with the [Typeform canonical standard](https://www.notion.so/typeform/Keeping-dependencies-updated-10c23dfc4c008038b02bebcb88de6867).

Specific changes are described in the diff — typical fixes include adding the `cooldown` block for npm, fixing commit-message prefixes (`ci(dependabot)` → `fix(dependabot)`, `fix(dependabot)` → `build(dependabot)` for github-actions), and adding required `registries` blocks.

## Test plan

- [ ] Merge and wait for the next Sunday Dependabot run
- [ ] Verify grouped PRs continue to open on schedule
- [ ] Confirm commit messages use the corrected prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
